### PR TITLE
Update CiviCRM and remove 'mysql' extension

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -24,7 +24,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update \
 
 # Install additional PHP extentions
 RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap intl mcrypt mysql mysqli soap
+  && docker-php-ext-install imap intl mcrypt mysqli soap
 
 # Install ssmtp
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -fSL http://files.drush.org/drush.phar -o /usr/local/bin/drush \
 # COPY civicrm.drush.inc /usr/share/drush/commands/civicrm.drush.inc
 
 # Download CiviCRM
-ENV CIVICRM_VERSION 4.7.6
+ENV CIVICRM_VERSION 4.7.17
 RUN curl -fSL "https://download.civicrm.org/civicrm-${CIVICRM_VERSION}-drupal.tar.gz" -o /var/www/civicrm.tar.gz
 
 # Install default error pages

--- a/app/civi_install.sh
+++ b/app/civi_install.sh
@@ -94,8 +94,6 @@ drush -y civicrm-install \
   --ssl=on \
   --load_generated_data=0
 
-rm /var/www/civicrm.tar.gz
-
 # TODO: there must be a better way....
 chown -R root:www-data ${WEB_ROOT}/sites/all/modules/civicrm
 chown -R root:www-data ${WEB_ROOT}/sites/default/files/civicrm

--- a/app/civi_install.sh
+++ b/app/civi_install.sh
@@ -21,7 +21,7 @@ drush -y site-install minimal \
   --account-name=${DEFAULT_ACCOUNT} \
   --account-pass=${DEFAULT_ACCOUNT_PASS} \
   --account-mail=${DEFAULT_ACCOUNT_MAIL} \
-  --db-url="mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db/${MYSQL_DATABASE}" \
+  --db-url="mysqli://${MYSQL_USER}:${MYSQL_PASSWORD}@db/${MYSQL_DATABASE}" \
   --site-name=${SITE_NAME} \
   --site-mail=${SITE_MAIL}
 


### PR DESCRIPTION
The mysql extension is unavailable as of PHP 7.0.0, preventing the app image from building. I updated the CiviCRM version as well.